### PR TITLE
Admin Can Add Items

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,6 +4,22 @@ class ItemsController < ApplicationController
   end
 
   def new
+    @item = Item.new
   end
-  
+
+  def create
+    @item = Item.new(item_params)
+    if @item.save
+      redirect_to store_path
+    else
+      render :new
+    end
+  end
+
+  private
+
+    def item_params
+      params.require(:item).permit(:title, :description, :price)
+    end
+
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -11,6 +11,7 @@
     <% @items.map do |item| %>
     <div class="col s4">
       <p><%= item.title %></p>
+      <p><%= item.description %></p>
     </div>
     <% end %>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -12,6 +12,7 @@
     <div class="col s4">
       <p><%= item.title %></p>
       <p><%= item.description %></p>
+      <p><%= item.price %></p>
     </div>
     <% end %>
   </div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -5,7 +5,7 @@
     </div>
   </div>
 
-  <%= form_for :item do |f| %>
+  <%= form_for @item do |f| %>
   <div class="row">
     <div class="input-field col s12">
       <%= f.label      :title %>
@@ -28,20 +28,14 @@
   </div>
 
   <div class="row">
-    <div class="input-field col s12">
-      <%= f.label      :image %>
-      <%= f.text_field :image %>
-    </div>
-  </div>
-
-  <div class="row">
     <div class="input-field col s2">
-      <%= f.submit     "Add Item", class: "waves-effect waves-light btn black" %>
+      <%= f.submit     "Add Item",
+                        class: "waves-effect waves-light btn black" %>
     </div>
   <% end %>
     <div class="input-field col s2">
-      <%= link_to      "Cancel",
-                       store_path, class: "waves-effect waves-light btn black" %>
+      <%= link_to      "Cancel", store_path,
+                        class: "waves-effect waves-light btn black" %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,5 @@ Rails.application.routes.draw do
   get "/about",      to: "about#index"
   get "/store",      to: "items#index"
 
-  resources :items, only: [:new]
+  resources :items, only: [:new, :create]
 end

--- a/db/migrate/20160125194027_add_columns_to_items.rb
+++ b/db/migrate/20160125194027_add_columns_to_items.rb
@@ -1,0 +1,6 @@
+class AddColumnsToItems < ActiveRecord::Migration
+  def change
+    add_column :items, :description, :text
+    add_column :items, :price, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160121074240) do
+ActiveRecord::Schema.define(version: 20160125194027) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,8 +23,10 @@ ActiveRecord::Schema.define(version: 20160121074240) do
 
   create_table "items", force: :cascade do |t|
     t.string   "title"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+    t.text     "description"
+    t.integer  "price"
   end
 
 end

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe ItemsController, type: :controller do
-
+  
 end

--- a/spec/features/admin_adds_item_spec.rb
+++ b/spec/features/admin_adds_item_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.feature "Admin can add a new item", type: :feature do
+  before do
+    login
+  end
+
+  scenario "successfully" do
+    visit new_item_path
+    fill_in "Title",       with: "My First Item"
+    fill_in "Description", with: "A great piece"
+    fill_in "Price",       with: 8
+
+    click_on "Add Item"
+
+    expect(current_path).to eq(store_path)
+    expect(page).to have_content("My First Item")
+    expect(page).to have_content("A great piece")
+  end
+end

--- a/spec/features/admin_views_new_item_page_spec.rb
+++ b/spec/features/admin_views_new_item_page_spec.rb
@@ -14,7 +14,6 @@ RSpec.feature "Admin can visit add item page", type: :feature do
     expect(page).to have_content("Title")
     expect(page).to have_content("Description")
     expect(page).to have_content("Price")
-    expect(page).to have_content("Image")
     expect(page).to have_button("Add Item")
 
     click_on "Cancel"

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe Item, type: :model do
-  
+
 end


### PR DESCRIPTION
Why: The Admin should be able to add Items to the Store and specify a
title (string), description (text), and price (integer).

This change addresses the need by:
- Adding a route, and controller action Items#create that redirected to
  the Items index (store page) if the new Item can be saved and
  re-renders the new form if the Item cannot be saved
- Adding columns for description and price to the Items table
- Adding a field to display the description on the Items index page
- Removing the image field from the new items form until Carrierwave can
  is implemented
