### PR TITLE
Admin Can Upload Item Images

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,10 @@ gem 'materialize-sass'
 gem 'rails_12factor'
 gem 'figaro'
 
+# Image Uploading
+
+gem "aws-sdk-v1"
+gem "paperclip"
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.4.0)
     arel (6.0.3)
+    aws-sdk-v1 (1.65.0)
+      json (~> 1.4)
+      nokogiri (>= 1.4.4)
     bcrypt (3.1.10)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
@@ -52,6 +55,10 @@ GEM
       xpath (~> 2.0)
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
+    climate_control (0.0.3)
+      activesupport (>= 3.0)
+    cocaine (0.5.7)
+      climate_control (>= 0.0.3, < 1.0)
     coderay (1.1.0)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
@@ -90,11 +97,18 @@ GEM
       sass (~> 3.3)
     method_source (0.8.2)
     mime-types (2.99)
+    mimemagic (0.3.0)
     mini_portile2 (2.0.0)
     minitest (5.8.4)
     multi_json (1.11.2)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
+    paperclip (4.3.0)
+      activemodel (>= 3.2.0)
+      activesupport (>= 3.2.0)
+      cocaine (~> 0.5.5)
+      mime-types
+      mimemagic (= 0.3.0)
     pg (0.18.4)
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -201,6 +215,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-v1
   bcrypt (~> 3.1.7)
   byebug
   capybara
@@ -211,6 +226,7 @@ DEPENDENCIES
   jquery-rails
   launchy
   materialize-sass
+  paperclip
   pg
   pry-rails
   rails (= 4.2.4)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,2 +1,4 @@
 class Item < ActiveRecord::Base
+  has_attached_file :item_image, styles: { large: "800x800>", medium: "300x300>", thumb: "100x100>" }, default_url: "/images/:style/missing.png"
+  validates_attachment_content_type :item_image, content_type: /\Aimage\/.*\Z/
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -9,7 +9,7 @@
 
   <div class="row">
     <% @items.map do |item| %>
-    <div class="col s4">
+    <div class="col s4" style="background-image:url('<%= item.item_image.url(:medium) %>')">
       <p><%= item.title %></p>
       <p><%= item.description %></p>
       <p><%= item.price %></p>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -5,7 +5,7 @@
     </div>
   </div>
 
-  <%= form_for @item do |f| %>
+  <%= form_for @item, multipart: true do |f| %>
   <div class="row">
     <div class="input-field col s12">
       <%= f.label      :title %>
@@ -24,6 +24,13 @@
     <div class="input-field col s12">
       <%= f.label      :price %>
       <%= f.text_field :price %>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="input-field col s12">
+      <%= f.label      :item_image %>
+      <%= f.file_field :item_image %>
     </div>
   </div>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,4 +38,15 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+    config.paperclip_defaults = {
+      :storage => :s3,
+      :s3_credentials => {
+        :bucket => ENV['AWS_S3_BUCKET'],
+        :access_key_id => ENV['AWS_ACCESS_KEY_ID'],
+        :secret_access_key => ENV['AWS_SECRET_ACCESS_KEY']
+      }
+    }
 end
+
+Paperclip.options[:command_path] = "/usr/local/bin/"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,4 +76,13 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  config.paperclip_defaults = config.paperclip_defaults = {
+    :storage => :s3,
+    :s3_credentials => {
+      :bucket => ENV['AWS_S3_BUCKET'],
+      :access_key_id => ENV['AWS_ACCESS_KEY_ID'],
+      :secret_access_key => ENV['AWS_SECRET_ACCESS_KEY']
+    }
+  }
 end

--- a/db/migrate/20160126080648_add_attachment_item_image_to_items.rb
+++ b/db/migrate/20160126080648_add_attachment_item_image_to_items.rb
@@ -1,0 +1,11 @@
+class AddAttachmentItemImageToItems < ActiveRecord::Migration
+  def self.up
+    change_table :items do |t|
+      t.attachment :item_image
+    end
+  end
+
+  def self.down
+    remove_attachment :items, :item_image
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160125194027) do
+ActiveRecord::Schema.define(version: 20160126080648) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,10 +23,14 @@ ActiveRecord::Schema.define(version: 20160125194027) do
 
   create_table "items", force: :cascade do |t|
     t.string   "title"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at",              null: false
+    t.datetime "updated_at",              null: false
     t.text     "description"
     t.integer  "price"
+    t.string   "item_image_file_name"
+    t.string   "item_image_content_type"
+    t.integer  "item_image_file_size"
+    t.datetime "item_image_updated_at"
   end
 
 end


### PR DESCRIPTION
Why: The Admin should be able to upload an image for each item in the
store

This change addresses the need by:
- Adding 'aws-sdk-v1' gem for AWS S3 compatibility
- Adding 'paperclip' gem for image uploading
- Setting 'paperclip' configurations in development.rb and production.rb
- Generating paperclip migration to add :item_image column to :items
  table
- Adding Paperclip settings has_attached_file and
  validates_attachment_content_type to Item model
- Setting large(800X800), medium(300x300), and thumb(100X100) image
  sizes for image processing when uploaded to model
- Setting "multipart: true" to new Item form in new.html.erb
- Defining <style> attribute to <div> with Item information on the
  Items index (store page)
